### PR TITLE
ci: update deploy region to eu-west-2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: eu-west-1
+          aws-region: eu-west-2
 
       - run: aws s3 sync dist/ s3://${{ vars.S3_BUCKET_NAME }} --delete
 


### PR DESCRIPTION
## Summary
- Change AWS deploy region from `eu-west-1` to `eu-west-2` in deploy workflow

## Test plan
- [ ] Verify deploy workflow triggers and deploys to correct region

🤖 Generated with [Claude Code](https://claude.com/claude-code)