### PR TITLE
ci: add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to deploy workflow, enabling manual deploys from GitHub Actions UI or CLI

## Test plan
- [ ] Verify "Run workflow" button appears on Actions tab for the Deploy workflow
- [ ] Trigger manual deploy and confirm it runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)