### PR TITLE
fix: external link icon + iOS zoom + AWS cert label

### DIFF
--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -152,7 +152,7 @@ export function TerminalInput({
 						onKeyDown={disabled ? undefined : handleKeyDown}
 						placeholder={disabled ? "" : PLACEHOLDER}
 						aria-label="Terminal input"
-						className="w-full bg-transparent text-transparent caret-transparent outline-none p-0 placeholder:text-transparent"
+						className="w-full bg-transparent text-transparent caret-transparent outline-none p-0 placeholder:text-transparent text-[16px]"
 						autoComplete="off"
 						autoCapitalize="off"
 						autoCorrect="off"

--- a/src/components/commands/LinksOutput.tsx
+++ b/src/components/commands/LinksOutput.tsx
@@ -1,3 +1,4 @@
+import { ExternalLinkIcon } from "@/components/icons/ExternalLinkIcon";
 import { links } from "@/content/data";
 import { useStreamLines } from "@/hooks/useStreamLines";
 
@@ -13,9 +14,10 @@ export function LinksOutput() {
 						href={link.url}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="text-coral hover:underline"
+						className="text-coral underline underline-offset-2 hover:no-underline inline-flex items-center gap-1"
 					>
 						{link.url.replace(/^(mailto:|https?:\/\/)/, "")}
+						{!link.url.startsWith("mailto:") && <ExternalLinkIcon />}
 					</a>
 				</div>
 			))}

--- a/src/components/commands/ProjectsOutput.tsx
+++ b/src/components/commands/ProjectsOutput.tsx
@@ -1,3 +1,4 @@
+import { ExternalLinkIcon } from "@/components/icons/ExternalLinkIcon";
 import { projects } from "@/content/data";
 import { useStreamLines } from "@/hooks/useStreamLines";
 
@@ -20,9 +21,10 @@ function ProjectCard({ project }: { project: (typeof projects)[number] }) {
 				href={project.url}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="text-coral hover:underline text-sm inline-block"
+				className="text-coral underline underline-offset-2 hover:no-underline text-sm inline-flex items-center gap-1"
 			>
-				→ GitHub
+				GitHub
+				<ExternalLinkIcon />
 			</a>
 		</div>
 	);

--- a/src/components/commands/WhoamiOutput.tsx
+++ b/src/components/commands/WhoamiOutput.tsx
@@ -1,3 +1,4 @@
+import { ExternalLinkIcon } from "@/components/icons/ExternalLinkIcon";
 import { identity } from "@/content/data";
 import { useStreamLines } from "@/hooks/useStreamLines";
 
@@ -21,9 +22,10 @@ export function WhoamiOutput() {
 								href={cert.url}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="text-coral hover:underline"
+								className="text-coral underline underline-offset-2 hover:no-underline inline-flex items-center gap-1"
 							>
 								{cert.label}
+								<ExternalLinkIcon />
 							</a>
 						</p>
 					))}

--- a/src/components/icons/ExternalLinkIcon.tsx
+++ b/src/components/icons/ExternalLinkIcon.tsx
@@ -1,0 +1,23 @@
+type ExternalLinkIconProps = {
+	size?: number;
+};
+
+export function ExternalLinkIcon({ size = 12 }: ExternalLinkIconProps) {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M15 3h6v6" />
+			<path d="M10 14 21 3" />
+			<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+		</svg>
+	);
+}

--- a/src/content/data.ts
+++ b/src/content/data.ts
@@ -10,8 +10,8 @@ export const identity = {
 	],
 	certifications: [
 		{
-			label: "AWS Solutions Architect Associate",
-			url: "https://www.credly.com/badges/5765cd81-1a6c-48ef-b498-d1e5e9ab63a5",
+			label: "AWS Solutions Architect Associate Certified",
+			url: "https://www.credly.com/badges/f2170eb0-99b3-4e0d-812c-fc9d8e4b5468/public_url",
 		},
 	],
 } as const;


### PR DESCRIPTION
## Summary
- Added `ExternalLinkIcon` shared component (Lucide) used in links, projects, and whoami outputs
- Fixed AWS Solutions Architect Associate cert label and Credly URL
- Set terminal input font-size to 16px to prevent iOS zoom-on-focus (which broke scroll-to-bottom on iPhone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)