### PR TITLE
fix: terminal accepts bare commands + cycling hint + smarter chips

### DIFF
--- a/src/components/Terminal/CyclingHint.test.tsx
+++ b/src/components/Terminal/CyclingHint.test.tsx
@@ -58,13 +58,11 @@ describe("CyclingHint", () => {
 	it("does not advance when prefers-reduced-motion is set", () => {
 		mockMatchMedia(true);
 		render(<CyclingHint paused={false} />);
-		const before = commandList.find((c) => screen.queryByText(c) !== null) as string;
-		expect(before).toBeDefined();
+		const initial = screen.getByText(/^\/[a-z]+$/).textContent;
 		act(() => {
 			vi.advanceTimersByTime(5000);
 		});
-		const after = commandList.find((c) => screen.queryByText(c) !== null) as string;
-		expect(after).toBe(before);
+		expect(screen.getByText(/^\/[a-z]+$/).textContent).toBe(initial);
 	});
 
 	it("unmounting mid-fade does not throw or warn", () => {

--- a/src/components/Terminal/CyclingHint.test.tsx
+++ b/src/components/Terminal/CyclingHint.test.tsx
@@ -1,0 +1,83 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { commands } from "@/content/data";
+import { CyclingHint } from "./CyclingHint";
+
+const commandList = Object.keys(commands);
+
+function mockMatchMedia(reduced: boolean) {
+	window.matchMedia = ((query: string) => ({
+		matches: query.includes("reduce") ? reduced : false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	})) as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+	cleanup();
+	vi.useFakeTimers();
+	mockMatchMedia(false);
+});
+
+afterEach(() => {
+	vi.runOnlyPendingTimers();
+	vi.useRealTimers();
+	cleanup();
+});
+
+describe("CyclingHint", () => {
+	it("renders the first command initially", () => {
+		render(<CyclingHint paused={false} />);
+		expect(screen.getByText(commandList[0] as string)).toBeInTheDocument();
+	});
+
+	it("advances to the next command after the cycle interval", () => {
+		render(<CyclingHint paused={false} />);
+		expect(screen.getByText(commandList[0] as string)).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(2000);
+			vi.advanceTimersByTime(200);
+		});
+		expect(screen.getByText(commandList[1] as string)).toBeInTheDocument();
+	});
+
+	it("does not advance when paused", () => {
+		render(<CyclingHint paused={true} />);
+		expect(screen.getByText(commandList[0] as string)).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+		expect(screen.getByText(commandList[0] as string)).toBeInTheDocument();
+	});
+
+	it("does not advance when prefers-reduced-motion is set", () => {
+		mockMatchMedia(true);
+		render(<CyclingHint paused={false} />);
+		const before = commandList.find((c) => screen.queryByText(c) !== null) as string;
+		expect(before).toBeDefined();
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+		const after = commandList.find((c) => screen.queryByText(c) !== null) as string;
+		expect(after).toBe(before);
+	});
+
+	it("unmounting mid-fade does not throw or warn", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { unmount } = render(<CyclingHint paused={false} />);
+		act(() => {
+			vi.advanceTimersByTime(2000);
+		});
+		unmount();
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(errorSpy).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
+	});
+});

--- a/src/components/Terminal/CyclingHint.tsx
+++ b/src/components/Terminal/CyclingHint.tsx
@@ -58,10 +58,7 @@ export function CyclingHint({ paused }: CyclingHintProps) {
 			Try typing{" "}
 			<span className="inline-block text-coral" style={{ minWidth: `${longestCommand.length}ch` }}>
 				<span
-					style={{
-						opacity: visible ? 1 : 0,
-						transition: `opacity ${FADE_MS}ms ease`,
-					}}
+					className={`transition-opacity duration-200 ease-in-out ${visible ? "opacity-100" : "opacity-0"}`}
 				>
 					{current}
 				</span>

--- a/src/components/Terminal/CyclingHint.tsx
+++ b/src/components/Terminal/CyclingHint.tsx
@@ -5,6 +5,8 @@ const CYCLE_MS = 2000;
 const FADE_MS = 200;
 
 const commandList = Object.keys(commands);
+const FALLBACK = "/help";
+const longestCommand = commandList.reduce((a, b) => (a.length >= b.length ? a : b), FALLBACK);
 
 function prefersReducedMotion(): boolean {
 	if (typeof window === "undefined") return false;
@@ -18,31 +20,43 @@ type CyclingHintProps = {
 export function CyclingHint({ paused }: CyclingHintProps) {
 	const reducedMotion = useMemo(prefersReducedMotion, []);
 	const initialIndex = useMemo(
-		() => (reducedMotion ? Math.floor(Math.random() * commandList.length) : 0),
+		() =>
+			commandList.length === 0
+				? 0
+				: reducedMotion
+					? Math.floor(Math.random() * commandList.length)
+					: 0,
 		[reducedMotion],
 	);
 	const [index, setIndex] = useState(initialIndex);
 	const [visible, setVisible] = useState(true);
 
 	useEffect(() => {
-		if (reducedMotion || paused) return;
+		if (reducedMotion || paused || commandList.length === 0) {
+			setVisible(true);
+			return;
+		}
+		let fadeTimeout: number | undefined;
 		const interval = window.setInterval(() => {
 			setVisible(false);
-			window.setTimeout(() => {
+			fadeTimeout = window.setTimeout(() => {
 				setIndex((i) => (i + 1) % commandList.length);
 				setVisible(true);
 			}, FADE_MS);
 		}, CYCLE_MS);
-		return () => window.clearInterval(interval);
+		return () => {
+			window.clearInterval(interval);
+			if (fadeTimeout !== undefined) window.clearTimeout(fadeTimeout);
+			setVisible(true);
+		};
 	}, [reducedMotion, paused]);
 
-	const longest = useMemo(() => commandList.reduce((a, b) => (a.length >= b.length ? a : b)), []);
-	const current = commandList[index] ?? commandList[0] ?? "/help";
+	const current = commandList[index] ?? FALLBACK;
 
 	return (
 		<>
 			Try typing{" "}
-			<span className="inline-block text-coral" style={{ minWidth: `${longest.length}ch` }}>
+			<span className="inline-block text-coral" style={{ minWidth: `${longestCommand.length}ch` }}>
 				<span
 					style={{
 						opacity: visible ? 1 : 0,

--- a/src/components/Terminal/CyclingHint.tsx
+++ b/src/components/Terminal/CyclingHint.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, useState } from "react";
+import { commands } from "@/content/data";
+
+const CYCLE_MS = 2000;
+const FADE_MS = 200;
+
+const commandList = Object.keys(commands);
+
+function prefersReducedMotion(): boolean {
+	if (typeof window === "undefined") return false;
+	return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+type CyclingHintProps = {
+	paused: boolean;
+};
+
+export function CyclingHint({ paused }: CyclingHintProps) {
+	const reducedMotion = useMemo(prefersReducedMotion, []);
+	const initialIndex = useMemo(
+		() => (reducedMotion ? Math.floor(Math.random() * commandList.length) : 0),
+		[reducedMotion],
+	);
+	const [index, setIndex] = useState(initialIndex);
+	const [visible, setVisible] = useState(true);
+
+	useEffect(() => {
+		if (reducedMotion || paused) return;
+		const interval = window.setInterval(() => {
+			setVisible(false);
+			window.setTimeout(() => {
+				setIndex((i) => (i + 1) % commandList.length);
+				setVisible(true);
+			}, FADE_MS);
+		}, CYCLE_MS);
+		return () => window.clearInterval(interval);
+	}, [reducedMotion, paused]);
+
+	const longest = useMemo(() => commandList.reduce((a, b) => (a.length >= b.length ? a : b)), []);
+	const current = commandList[index] ?? commandList[0] ?? "/help";
+
+	return (
+		<>
+			Try typing{" "}
+			<span className="inline-block text-coral" style={{ minWidth: `${longest.length}ch` }}>
+				<span
+					style={{
+						opacity: visible ? 1 : 0,
+						transition: `opacity ${FADE_MS}ms ease`,
+					}}
+				>
+					{current}
+				</span>
+			</span>
+		</>
+	);
+}

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -149,6 +149,15 @@ describe("Terminal", () => {
 		expect(await screen.findByText(/nice try/i)).toBeInTheDocument();
 	});
 
+	it("focusing the input pauses the cycling hint", async () => {
+		const { input } = await renderTerminal();
+		const hint = () => screen.getByText(/^\/[a-z]+$/);
+		const before = hint().textContent;
+		input.focus();
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(hint().textContent).toBe(before);
+	});
+
 	it("'sudoku' does not trigger sudo egg", async () => {
 		const { user, input } = await renderTerminal();
 		await user.type(input, "sudoku{Enter}");

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -154,7 +154,9 @@ describe("Terminal", () => {
 		const hint = () => screen.getByText(/^\/[a-z]+$/);
 		const before = hint().textContent;
 		input.focus();
-		await vi.advanceTimersByTimeAsync(5000);
+		await vi.advanceTimersByTimeAsync(2200);
+		expect(hint().textContent).toBe(before);
+		await vi.advanceTimersByTimeAsync(2200);
 		expect(hint().textContent).toBe(before);
 	});
 

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -149,6 +149,13 @@ describe("Terminal", () => {
 		expect(await screen.findByText(/nice try/i)).toBeInTheDocument();
 	});
 
+	it("'sudoku' does not trigger sudo egg", async () => {
+		const { user, input } = await renderTerminal();
+		await user.type(input, "sudoku{Enter}");
+		expect(screen.queryByText(/nice try/i)).not.toBeInTheDocument();
+		expect(await screen.findByText(/command not found/i)).toBeInTheDocument();
+	});
+
 	it("ls easter egg lists commands", async () => {
 		const { user, input } = await renderTerminal();
 		await user.type(input, "ls{Enter}");

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -80,9 +80,27 @@ describe("Terminal", () => {
 		await waitFor(() => expect(screen.queryByText(/WorldFirst/i)).not.toBeInTheDocument());
 	});
 
-	it("unknown command shows error and suggests /help", async () => {
+	it("unknown command shows error", async () => {
 		const { user, input } = await renderTerminal();
 		await user.type(input, "/nope{Enter}");
+		expect(await screen.findByText(/command not found/i)).toBeInTheDocument();
+	});
+
+	it("bare 'help' (no slash) runs /help", async () => {
+		const { user, input } = await renderTerminal();
+		await user.type(input, "help{Enter}");
+		expect(await screen.findByText("Available commands:")).toBeInTheDocument();
+	});
+
+	it("bare command is case-insensitive", async () => {
+		const { user, input } = await renderTerminal();
+		await user.type(input, "WHOAMI{Enter}");
+		expect(await screen.findByText(/WorldFirst/i)).toBeInTheDocument();
+	});
+
+	it("bare typo still shows error", async () => {
+		const { user, input } = await renderTerminal();
+		await user.type(input, "halp{Enter}");
 		expect(await screen.findByText(/command not found/i)).toBeInTheDocument();
 	});
 
@@ -221,6 +239,53 @@ describe("Terminal", () => {
 			await user.click(await screen.findByRole("button", { name: "/skills" }));
 			await user.keyboard("{ArrowUp}");
 			expect(input.value).toBe("/whoami");
+		});
+
+		it("typing a lone '/' shows all available command chips", async () => {
+			const { user, input } = await renderTerminal();
+			await user.type(input, "/");
+			const list = chipsList();
+			expect(list).not.toBeNull();
+			for (const cmd of [
+				"/help",
+				"/clear",
+				"/whoami",
+				"/skills",
+				"/links",
+				"/projects",
+				"/experience",
+			]) {
+				expect(within(list as HTMLElement).getByRole("button", { name: cmd })).toBeInTheDocument();
+			}
+		});
+
+		it("substring match: typing 's' surfaces every command containing s", async () => {
+			const { user, input } = await renderTerminal();
+			await user.type(input, "s");
+			const list = chipsList();
+			expect(list).not.toBeNull();
+			expect(
+				within(list as HTMLElement).getByRole("button", { name: "/skills" }),
+			).toBeInTheDocument();
+			expect(
+				within(list as HTMLElement).getByRole("button", { name: "/links" }),
+			).toBeInTheDocument();
+			expect(
+				within(list as HTMLElement).getByRole("button", { name: "/projects" }),
+			).toBeInTheDocument();
+			expect(
+				within(list as HTMLElement).queryByRole("button", { name: "/whoami" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("bare prefix without slash shows matching chips (case-insensitive)", async () => {
+			const { user, input } = await renderTerminal();
+			await user.type(input, "HE");
+			const list = chipsList();
+			expect(list).not.toBeNull();
+			expect(
+				within(list as HTMLElement).getByRole("button", { name: "/help" }),
+			).toBeInTheDocument();
 		});
 
 		it("chips never throw on whitespace or unicode input — only real command matches", async () => {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -70,7 +70,12 @@ export function Terminal({ profilePictureSrc }: TerminalProps) {
 							<WelcomeBox profilePictureSrc={profilePictureSrc} />
 							<p className="text-yellow text-sm font-mono mt-3 mb-3">
 								{draftTrimmed ? (
-									`Press Enter to run ${draftTrimmed}`
+									<>
+										Press Enter to run{" "}
+										<span className="inline-block max-w-full align-bottom truncate">
+											{draftTrimmed}
+										</span>
+									</>
 								) : (
 									<>
 										This is an interactive portfolio. Type a command, then press Enter ↵ to explore.

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import { dispatch } from "@/components/commands/registry";
 import { useAutoScroll } from "@/hooks/useAutoScroll";
 import { useGreeting } from "@/hooks/useGreeting";
+import { CyclingHint } from "./CyclingHint";
 import { ScrollIndicator } from "./ScrollIndicator";
 import { StatusBar } from "./StatusBar";
 import { TerminalInput } from "./TerminalInput";
@@ -51,10 +52,9 @@ export function Terminal({ profilePictureSrc }: TerminalProps) {
 	const { containerRef, showIndicator, handleScroll, scrollToBottom, forceScrollToBottom } =
 		useAutoScroll([entries.length, welcomeVisible]);
 
+	const [inputFocused, setInputFocused] = useState(false);
 	const draftTrimmed = inputDraft.trim();
-	const hintMessage = draftTrimmed
-		? `Press Enter to run ${draftTrimmed}`
-		: "This is an interactive portfolio. Type a command, then press Enter ↵ to explore";
+	const isEngaged = draftTrimmed.length > 0 || inputFocused;
 
 	return (
 		<div className="flex flex-col h-[100dvh] bg-base overflow-x-hidden">
@@ -68,7 +68,18 @@ export function Terminal({ profilePictureSrc }: TerminalProps) {
 					{welcomeVisible && (
 						<>
 							<WelcomeBox profilePictureSrc={profilePictureSrc} />
-							<p className="text-yellow text-sm font-mono mt-3 mb-3">{hintMessage}</p>
+							<p className="text-yellow text-sm font-mono mt-3 mb-3">
+								{draftTrimmed ? (
+									`Press Enter to run ${draftTrimmed}`
+								) : (
+									<>
+										This is an interactive portfolio. Type a command, then press Enter ↵ to explore.
+										<span className="block pt-2">
+											<CyclingHint paused={isEngaged} />
+										</span>
+									</>
+								)}
+							</p>
 						</>
 					)}
 					{entries.map((entry, idx) => {
@@ -116,6 +127,7 @@ export function Terminal({ profilePictureSrc }: TerminalProps) {
 					]);
 				}}
 				onValueChange={setInputDraft}
+				onFocusChange={setInputFocused}
 				history={history}
 				disabled={inputDisabled}
 			/>

--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -5,23 +5,30 @@ type TerminalInputProps = {
 	onSubmit: (value: string) => void;
 	onShowCompletions: (matches: string[]) => void;
 	onValueChange?: (value: string) => void;
+	onFocusChange?: (focused: boolean) => void;
 	history: string[];
 	disabled?: boolean;
 };
 
 const commandNames = Object.keys(commands);
-const PLACEHOLDER = "type /help or tap a suggestion";
+const PLACEHOLDER = "type help or tap a suggestion";
 
 function getMatches(value: string): string[] {
-	const trimmed = value.trim();
+	const trimmed = value.trim().toLowerCase();
 	if (!trimmed) return [];
-	return commandNames.filter((cmd) => cmd.startsWith(trimmed) && cmd !== trimmed);
+	const needle = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+	if (!needle) return commandNames;
+	return commandNames.filter((cmd) => {
+		const bare = cmd.slice(1);
+		return bare.includes(needle) && bare !== needle;
+	});
 }
 
 export function TerminalInput({
 	onSubmit,
 	onShowCompletions,
 	onValueChange,
+	onFocusChange,
 	history,
 	disabled = false,
 }: TerminalInputProps) {
@@ -60,9 +67,11 @@ export function TerminalInput({
 	function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
 		if (e.key === "Tab") {
 			e.preventDefault();
-			const input = value.trim();
-			if (!input) return;
-			const tabMatches = commandNames.filter((cmd) => cmd.startsWith(input));
+			const trimmed = value.trim().toLowerCase();
+			if (!trimmed) return;
+			const needle = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+			if (!needle) return;
+			const tabMatches = commandNames.filter((cmd) => cmd.slice(1).startsWith(needle));
 			if (tabMatches.length === 1 && tabMatches[0]) {
 				setValue(tabMatches[0]);
 			} else if (tabMatches.length > 1) {
@@ -150,6 +159,8 @@ export function TerminalInput({
 							updateValue(e.target.value);
 						}}
 						onKeyDown={disabled ? undefined : handleKeyDown}
+						onFocus={() => onFocusChange?.(true)}
+						onBlur={() => onFocusChange?.(false)}
 						placeholder={disabled ? "" : PLACEHOLDER}
 						aria-label="Terminal input"
 						className="w-full bg-transparent text-transparent caret-transparent outline-none p-0 placeholder:text-transparent text-[16px]"

--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -13,6 +13,10 @@ type TerminalInputProps = {
 const commandNames = Object.keys(commands);
 const PLACEHOLDER = "type help or tap a suggestion";
 
+// Chips use substring match (`includes`) for discovery — typing any letter
+// surfaces every command containing it. Tab autocomplete below uses prefix
+// match instead, because Tab's contract is "complete the unique candidate"
+// and substring would be ambiguous.
 function getMatches(value: string): string[] {
 	const trimmed = value.trim().toLowerCase();
 	if (!trimmed) return [];

--- a/src/components/commands/ErrorOutput.tsx
+++ b/src/components/commands/ErrorOutput.tsx
@@ -1,26 +1,13 @@
-import { commands } from "@/content/data";
-
 type ErrorOutputProps = {
 	input: string;
 };
 
 export function ErrorOutput({ input }: ErrorOutputProps) {
 	const bare = input.trim();
-	const asCommand = `/${bare}`;
-	const isKnownBare = bare in commands;
-
-	if (isKnownBare) {
-		return (
-			<p className="text-yellow">
-				did you mean <span className="text-coral">{asCommand}</span>?
-			</p>
-		);
-	}
 
 	return (
 		<p className="text-red">
-			command not found: {bare.startsWith("/") ? bare : input} — try{" "}
-			<span className="text-coral">/help</span>
+			command not found: {bare} — try <span className="text-coral">help</span> or tap a suggestion
 		</p>
 	);
 }

--- a/src/components/commands/LinksOutput.tsx
+++ b/src/components/commands/LinksOutput.tsx
@@ -14,7 +14,7 @@ export function LinksOutput() {
 						href={link.url}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="text-coral underline underline-offset-2 hover:no-underline inline-flex items-center gap-1"
+						className="text-coral underline underline-offset-2 hover:no-underline"
 					>
 						{link.url.replace(/^(mailto:|https?:\/\/)/, "")}
 						{!link.url.startsWith("mailto:") && <ExternalLinkIcon />}

--- a/src/components/commands/ProjectsOutput.tsx
+++ b/src/components/commands/ProjectsOutput.tsx
@@ -21,7 +21,7 @@ function ProjectCard({ project }: { project: (typeof projects)[number] }) {
 				href={project.url}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="text-coral underline underline-offset-2 hover:no-underline text-sm inline-flex items-center gap-1"
+				className="text-coral underline underline-offset-2 hover:no-underline text-sm"
 			>
 				GitHub
 				<ExternalLinkIcon />

--- a/src/components/commands/WhoamiOutput.tsx
+++ b/src/components/commands/WhoamiOutput.tsx
@@ -22,7 +22,7 @@ export function WhoamiOutput() {
 								href={cert.url}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="text-coral underline underline-offset-2 hover:no-underline inline-flex items-center gap-1"
+								className="text-coral underline underline-offset-2 hover:no-underline"
 							>
 								{cert.label}
 								<ExternalLinkIcon />

--- a/src/components/commands/registry.tsx
+++ b/src/components/commands/registry.tsx
@@ -31,26 +31,25 @@ export function dispatch(raw: string, ctx: CommandContext): DispatchResult | nul
 	const input = raw.trim();
 	if (!input) return null;
 
-	if (input === "/clear") {
+	const egg = matchEasterEgg(input.toLowerCase());
+	if (egg) return { type: "output", node: egg };
+
+	const normalized = input.startsWith("/") ? input.toLowerCase() : `/${input.toLowerCase()}`;
+
+	if (normalized === "/clear") {
 		return { type: "clear" };
 	}
 
-	if (input.startsWith("/")) {
-		const handler = handlers[input];
-		if (handler) {
-			return { type: "output", node: handler(ctx) };
-		}
-		if (input in commands) {
-			return {
-				type: "output",
-				node: <p className="text-muted">{input} — coming soon</p>,
-			};
-		}
-		return { type: "output", node: <ErrorOutput input={input} /> };
+	const handler = handlers[normalized];
+	if (handler) {
+		return { type: "output", node: handler(ctx) };
 	}
-
-	const egg = matchEasterEgg(input);
-	if (egg) return { type: "output", node: egg };
+	if (normalized in commands) {
+		return {
+			type: "output",
+			node: <p className="text-muted">{normalized} — coming soon</p>,
+		};
+	}
 
 	return { type: "output", node: <ErrorOutput input={input} /> };
 }

--- a/src/components/commands/registry.tsx
+++ b/src/components/commands/registry.tsx
@@ -55,7 +55,7 @@ export function dispatch(raw: string, ctx: CommandContext): DispatchResult | nul
 }
 
 function matchEasterEgg(input: string): ReactNode | null {
-	if (input.startsWith("sudo")) return <SudoOutput />;
+	if (input === "sudo" || input.startsWith("sudo ")) return <SudoOutput />;
 	if (input === "ls" || input === "/ls") return <LsOutput />;
 	if (input === "cat" || input === "/cat") return <CatOutput />;
 	return null;

--- a/src/components/icons/ExternalLinkIcon.tsx
+++ b/src/components/icons/ExternalLinkIcon.tsx
@@ -14,6 +14,7 @@ export function ExternalLinkIcon({ size = 12 }: ExternalLinkIconProps) {
 			strokeLinecap="round"
 			strokeLinejoin="round"
 			aria-hidden="true"
+			className="inline-block align-[-0.125em] ml-1"
 		>
 			<path d="M15 3h6v6" />
 			<path d="M10 14 21 3" />


### PR DESCRIPTION
## Summary
- Terminal now accepts bare commands without slash (`help` ≡ `/help`), case-insensitive; "command not found" error reworded, placeholder de-biased
- New cycling hint below welcome line rotates through all commands every ~2s with crossfade, paused on focus/typing, respects reduced-motion
- Suggestion chips now substring-match, surface on bare input and on lone `/` (shows all); tab autocomplete updated to match

## Test plan
- [ ] Type `help` (no slash) — should execute `/help`
- [ ] Type `ABOUT` (uppercase) — should execute `/about`
- [ ] Type `/` alone — all command chips should appear
- [ ] Type partial bare word (e.g. `ab`) — matching chips appear
- [ ] Cycling hint visible on fresh load, pauses when input focused/typing, resumes after
- [ ] Prefers-reduced-motion: cycling hint shows first item only, no animation
- [ ] "Command not found" message no longer mentions slash prefix