### PR TITLE
update license year to 2026, fix infra repo URL in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Francesco Albanese
+Copyright (c) 2026 Francesco Albanese
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Interactive terminal-based portfolio website. Type commands to explore skills, e
 ### CI/CD Pipeline
 
 - **OIDC federation** for keyless AWS authentication (no long-lived credentials)
-- Infrastructure managed via Terraform in a [separate repository](https://github.com/francescoalbanese/francescoalbanese-dev-infra)
+- Infrastructure managed via Terraform in a [separate repository](https://github.com/francesco-albanese/francescoalbanese-dev-infra)
 
 ## Local Development
 


### PR DESCRIPTION
## Summary
- Update LICENSE copyright year from 2025 to 2026
- Fix GitHub username in infra repo URL (francescoalbanese -> francesco-albanese)

## Test plan
- [ ] Verify LICENSE shows 2026
- [ ] Verify README infra repo link points to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)